### PR TITLE
add schema documentation and use of stock_id in stock_coverage

### DIFF
--- a/Models/mart/mart_operations__stock_coverage.sql
+++ b/Models/mart/mart_operations__stock_coverage.sql
@@ -1,4 +1,5 @@
 SELECT
+    ag.stock_id,
     ag.store_id,
     ag.product_id,
     COALESCE(ag.avg_ordered_quantity_by_day, 0) AS avg_ordered_quantity_by_day,
@@ -10,7 +11,7 @@ SELECT
     cat.category_name
 FROM {{ ref('int_localbike_dataset__2018_avg_ordered_quantity' )}} AS ag
 LEFT JOIN {{ ref('stg_localbike_dataset__stock')}} AS stock
- ON ag.store_id = stock.store_id AND ag.product_id = stock.store_id
+ ON ag.stock_id = stock.stock_id 
 LEFT JOIN {{ ref('stg_localbike_dataset__store')}} AS store
  ON ag.store_id = store.store_id
 LEFT JOIN {{ ref('stg_localbike_dataset__product')}} AS pdt

--- a/Models/mart/schema.yml
+++ b/Models/mart/schema.yml
@@ -1,0 +1,31 @@
+version: 2
+
+models:
+
+  - name: mart_operations__stock_coverage
+    description: |
+      This model provides all key metrics needed to follow the stock coverage 
+      and avoid inventory shortage or help preventing/evaluating toxic stock 
+      (stock that we won't be able to sale).
+      It contains by store and by product the 2018 average demand (ultimate year),
+      the quantity in stock and product information like the price to evaluate the stock.
+    columns:
+
+      - name: stock_id
+        tests:
+          - unique
+          - not_null
+
+      - name: avg_ordered_quantity_by_day  
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: '>= 0'
+              
+      - name: stock_quantity  
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: '>= 0'
+
+      - name: product_price  
+        tests:
+          - not_null


### PR DESCRIPTION
add schema documentation with tests needed and use of stock_id in model stock_coverage to strengthen the link between stock table and average ordered quantity